### PR TITLE
Fix responsive design issues on landing page

### DIFF
--- a/css/landing-page.css
+++ b/css/landing-page.css
@@ -248,6 +248,17 @@ h6 {
         float: left;
         margin-top: 15px;
     }
+   
+   .content-section-a table.table,
+   .content-section-a table.table tr,
+   .content-section-b table.table,
+   .content-section-b table.table tr {
+      display:block;
+   }
+   .content-section-a table.table td,
+   .content-section-b table.table td {
+      display:inline-block;
+   }
 }
 
 @media(max-width:767px) {
@@ -266,6 +277,11 @@ h6 {
     ul.banner-social-buttons > li:last-child {
         margin-bottom: 0;
     }
+    
+   .intro-message > h1 {
+       text-shadow: 1px 1px 2px rgba(0,0,0,0.6);
+       font-size: 3em !important;
+   }
 }
 
 footer {


### PR DESCRIPTION
The title was far too big on cell phones so have halved the size below 767px. The Contributor/Friend logos overhung the container even sooner, so now display inline-block below 1199px. Not perfect, but should stop horizontal scrolling.
